### PR TITLE
trigger_scrape_metrics

### DIFF
--- a/data/metrics.yml
+++ b/data/metrics.yml
@@ -2,7 +2,7 @@ enable: true
 heading: METRICS
 counter_item:
 - title: Downloads
-  number: 17135
+  number: 1041592
 
 - title: Publications
   number: 27


### PR DESCRIPTION
I opened this PR to trigger the "Run Download Metrics On Demand" workflow by using the commit message "trigger_scrape_metrics" - but that workflow was still skipped.

https://github.com/NCAR/vast/actions/runs/2927347793/workflow

I adapted this code from the GeoCAT version. @erogluorhan could you help me understand why this workflow was not triggered?