### PR TITLE
Adds the Presentations page, navbar link, and metrics

### DIFF
--- a/.github/workflows/update-metrics.yaml
+++ b/.github/workflows/update-metrics.yaml
@@ -1,4 +1,4 @@
-name: Update Publications Metrics
+name: Update Metrics
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'data/publications.yml'
+      - 'data/presentations.yml'
       - 'data/packages.yml'
       - 'data/siparcs.yml'
     
@@ -30,12 +31,18 @@ jobs:
 
         metrics_file = 'data/metrics.yml'
         publications_file = 'data/publications.yml'
+        presentations file = 'data/presentations.yml'
         packages_file = 'data/packages.yml'
         siparcs_file = 'data/siparcs.yml'
           
         with open(publications_file) as f:
           publications_dict = yaml.load(f)
         publications = len(publications_dict['items'])
+
+        
+        with open(presentations_file) as f:
+          presentations_dict = yaml.load(f)
+        presentations = len(presentations_dict['items'])
         
         with open(packages_file) as f:
           packages_dict = yaml.load(f)
@@ -48,8 +55,9 @@ jobs:
         with open(metrics_file, 'r+') as f:
           metrics_dict = yaml.load(f)
         metrics_dict['counter_item'][1]["number"] = publications
-        metrics_dict['counter_item'][2]["number"] = packages
-        metrics_dict['counter_item'][3]["number"] = interns
+        metrics_dict['counter_item'][2]["number"] = presentations
+        metrics_dict['counter_item'][3]["number"] = packages
+        metrics_dict['counter_item'][4]["number"] = interns
         with open(metrics_file, 'w') as f:
           yaml.dump(metrics_dict, f)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ of this data file.
 
 #### Adding publications
 
-Edit `data/publications.yml` to add a new presentation or publication citation:
+Edit `data/publications.yml` to add a new publication citation:
 
 ````
   - title: Some journal article title.
@@ -120,6 +120,24 @@ Edit `data/publications.yml` to add a new presentation or publication citation:
 
 The `extra` field is optional and can contain journal volume information and page numbers.
 If the `url` field is specified, then the citation will hyperlink to the given URL.
+
+#### Adding presentations
+
+Edit `data/presentations.yml` to add a new presentation or publication citation:
+
+````
+  - title: Some presentation title.
+    authors:
+      - Last, F.
+    conference: The Most Prestigious Conference
+    year: 2023
+    extra: City, ST
+    url: https://example.com
+````
+
+The `extra` field is optional and can contain conference city, virtual nature, or any other information.
+
+Please sepcify the `url` field to be a link to a PDF file of the talk slides or poster uploaded to the [VAST Presentations Google Drive fodler](https://drive.google.com/drive/folders/146ZZgV5Pb0-scadJtrPEXfP_jhDYwKVL). Please use a naming convention akin to `Last_Topic_ConferenceYYYY` and be sure that the file's sharing settings allow anyone to view the file.
 
 #### Adding services
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Edit `data/presentations.yml` to add a new presentation or publication citation:
 
 The `extra` field is optional and can contain conference city, virtual nature, or any other information.
 
-Please sepcify the `url` field to be a link to a PDF file of the talk slides or poster uploaded to the [VAST Presentations Google Drive fodler](https://drive.google.com/drive/folders/146ZZgV5Pb0-scadJtrPEXfP_jhDYwKVL). Please use a naming convention akin to `Last_Topic_ConferenceYYYY` and be sure that the file's sharing settings allow anyone to view the file.
+Please specify the `url` field to be a link to a PDF file of the talk slides or poster uploaded to the [VAST Presentations Google Drive fodler](https://drive.google.com/drive/folders/146ZZgV5Pb0-scadJtrPEXfP_jhDYwKVL). Please use a naming convention akin to `Last_Topic_ConferenceYYYY` and be sure that the file's sharing settings allow anyone to view the file.
 
 #### Adding services
 

--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,9 @@ menu:
     - name      : Publications
       url       : publications
       weight    : 4
+    - name      : Presentations
+      url       : presentations
+      weight    : 4
     - name      : Internships
       url       : siparcs
       weight    : 4
@@ -73,6 +76,8 @@ params:
             url : news
           - name: Publications
             url : publications
+          - name: Presentations
+            url: presentations
           - name: Internships
             url : siparcs
         - link:

--- a/content/presentations/_index.md
+++ b/content/presentations/_index.md
@@ -1,0 +1,6 @@
+---
+title : "Presentations"
+date  : 2023-01-17T00:00:00-06:00
+---
+
+ccs

--- a/content/presentations/_index.md
+++ b/content/presentations/_index.md
@@ -2,5 +2,3 @@
 title : "Presentations"
 date  : 2023-01-17T00:00:00-06:00
 ---
-
-ccs

--- a/data/metrics.yml
+++ b/data/metrics.yml
@@ -8,6 +8,10 @@ counter_item:
   number: 27
   url: publications
 
+- title: Presentations
+  number: 0
+  url: presentations
+
 - title: Packages
   number: 9
 

--- a/data/metrics.yml
+++ b/data/metrics.yml
@@ -9,7 +9,7 @@ counter_item:
   url: publications
 
 - title: Presentations
-  number: 0
+  number: 23
   url: presentations
 
 - title: Packages

--- a/data/presentations.yml
+++ b/data/presentations.yml
@@ -4,13 +4,21 @@ image  : images/banners/aurora.jpg
 items  :
 
 
+  - title: NCAR Earth System Data Science Community - Making the Python Scientific Ecosystem More Accessible to GeoScientists
+    authors:
+      - Kent, J.
+    journal: AMS Python 2023
+    year: 2023
+    extra: Denver, CO
+    url: https://drive.google.com/file/d/1CYRszpd-x72CXOEwb6yNfqy5XdoGbE6g/view?usp=share_link
+
   - title: Project Pythia - A Pangeo Community Tool for Open-Source Education
     authors:
       - Kent, J.
     journal: AGU 2022
     year: 2022
     extra: Chicago, IL
-    url: https://docs.google.com/presentation/d/19oWV7LULijtIYObrNW3ccoRLNFV9lYA0APuPlXAx_z8/edit?usp=sharing
+    url: https://drive.google.com/file/d/1DPdDo73HMDK3njy5w2oDAXiG14J4zjaz/view?usp=share_link
 
   - title: Beyond Visuals - Examining the Experiences of Geoscience Professionals With Vision Disabilities in Accessing Data Visualizations
     authors:

--- a/data/presentations.yml
+++ b/data/presentations.yml
@@ -7,7 +7,7 @@ items  :
   - title: NCAR Earth System Data Science Community - Making the Python Scientific Ecosystem More Accessible to GeoScientists
     authors:
       - Kent, J.
-    journal: AMS Python 2023
+    conference: AMS Python 2023
     year: 2023
     extra: Denver, CO
     url: https://drive.google.com/file/d/1CYRszpd-x72CXOEwb6yNfqy5XdoGbE6g/view?usp=share_link
@@ -15,7 +15,7 @@ items  :
   - title: Project Pythia - A Pangeo Community Tool for Open-Source Education
     authors:
       - Kent, J.
-    journal: AGU 2022
+    conference: AGU 2022
     year: 2022
     extra: Chicago, IL
     url: https://drive.google.com/file/d/1DPdDo73HMDK3njy5w2oDAXiG14J4zjaz/view?usp=share_link
@@ -28,7 +28,7 @@ items  :
       - Fourment, T.
       - Hathaway, B.
       - Holland, M.
-    journal: IEEE Vis 2022
+    conference: IEEE Vis 2022
     year: 2022
     url:
 
@@ -38,7 +38,7 @@ items  :
       - Eroglu, O.
       - Zacharias, A.
       - Kootz, A.
-    journal: AMS Annual Meeting 2022
+    conference: AMS Annual Meeting 2022
     year: 2022
     url: https://ams.confex.com/ams/102ANNUAL/meetingapp.cgi/Paper/392637
 
@@ -49,14 +49,14 @@ items  :
       - Zacharias, A.
       - Sizemore, M.
       - Eroglu, O.
-    journal: AMS Annual Meeting 2022
+    conference: AMS Annual Meeting 2022
     year: 2022
     url: https://ams.confex.com/ams/102ANNUAL/meetingapp.cgi/Paper/395377
 
   - title: NCAR Earth System Data Science Initiative (ESDS) Educational Efforts
     authors:
       - Kent, J.
-    journal: AGU 2021
+    conference: AGU 2021
     year: 2021
     extra: New Orleans, LA
     url: https://drive.google.com/file/d/1pidWOdzD9S95M-e1OvC04pY_tD5hURea/view?usp=share_link
@@ -67,7 +67,7 @@ items  :
       - Eroglu, O.
       - Medeiros, B.
       - Zarzycki, C. M.
-    journal: AGU Fall Meeting 2021
+    conference: AGU Fall Meeting 2021
     year: 2021
     url: https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/901711
 
@@ -83,7 +83,7 @@ items  :
       - May, R.
       - Rose, B. E. J.
       - Tyle, K.
-    journal: AGU Fall Meeting 2021
+    conference: AGU Fall Meeting 2021
     year: 2021
     url: https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/831257
 
@@ -95,7 +95,7 @@ items  :
       - Sizemore, M.
       - Eroglu, O.
       - Kent, J.
-    journal: AGU Fall Meeting 2021
+    conference: AGU Fall Meeting 2021
     year: 2021
     url: https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/973469
 
@@ -106,7 +106,7 @@ items  :
       - Kootz, A.
       - Sizemore, M.
       - Zacharias, A.
-    journal: AMS Annual Meeting 2021
+    conference: AMS Annual Meeting 2021
     year: 2021
     url: https://ams.confex.com/ams/101ANNUAL/meetingapp.cgi/Paper/379186
 
@@ -115,14 +115,14 @@ items  :
       - Craker, H. R.
       - Fiorino, C. A.
       - Sizemore, M. V.
-    journal: AMS Annual Meeting 2021
+    conference: AMS Annual Meeting 2021
     year: 2021
     url: https://ams.confex.com/ams/101ANNUAL/meetingapp.cgi/Paper/378236
 
   - title: GeoCAT - The NCL Pivot to Python
     authors:
       - Clyne, J.
-    journal: AMS Annual Meeting 2020
+    conference: AMS Annual Meeting 2020
     year: 2020
     url: https://ams.confex.com/ams/2020Annual/meetingapp.cgi/Paper/365970
 
@@ -131,7 +131,7 @@ items  :
       - Cherukuru, N.
       - Scheitlin, T.
       - Rehme, M.
-    journal: AMS Annual Meeting 2018
+    conference: AMS Annual Meeting 2018
     year: 2018
     url:
 
@@ -140,7 +140,7 @@ items  :
       - Hayne, L.
       - Clyne, J.
       - Li, S.
-    journal: The Second International Workshop on Big Data Reduction (IWBDR)
+    conference: The Second International Workshop on Big Data Reduction (IWBDR)
     year: 2021
     url: ../pdfs/IWBDR_sub.pdf
 
@@ -149,7 +149,7 @@ items  :
       - Lessley, B.
       - Li, S.
       - Childs, H.
-    journal: IS&T Conference on Visualization and Data Analysis (VDA)
+    conference: IS&T Conference on Visualization and Data Analysis (VDA)
     year: 2020
     extra: Burlingame, CA
     url: https://doi.org/10.2352/ISSN.2470-1173.2020.1.VDA-376
@@ -160,7 +160,7 @@ items  :
       - Li, S.
       - Larsen, M.
       - Childs, H.
-    journal: Eurographics Symposium on Parallel Graphics and Visualization (EGPGV)
+    conference: Eurographics Symposium on Parallel Graphics and Visualization (EGPGV)
     year: 2019
     extra: Porto, Portugal
     url: https://cdux.cs.uoregon.edu/pubs/MarsagliaEGPGV.pdf
@@ -175,7 +175,7 @@ items  :
       - Guo, H.
       - Chen, Z.
       - Cappello, F.
-    journal: IEEE International Conference on Big Data
+    conference: IEEE International Conference on Big Data
     year: 2018
     extra: Seattle, WA
     url: https://ieeexplore.ieee.org/document/8622520
@@ -185,7 +185,7 @@ items  :
       - Marsaglia, N.
       - Li, S.
       - Childs, H.
-    journal: ISC Workshop On In Situ Visualization, Introduction & Applications (WOIV)
+    conference: ISC Workshop On In Situ Visualization, Introduction & Applications (WOIV)
     year: 2018
     extra: Frankfurt, Germany
     url: https://cdux.cs.uoregon.edu/pubs/MarsagliaWOIV.pdf
@@ -197,7 +197,7 @@ items  :
       - Larsen, M.
       - Clyne, J.
       - Childs, H.
-    journal: In Situ Infrastructures for Enabling Extreme-scale Analysis and Visualization (ISAV)
+    conference: In Situ Infrastructures for Enabling Extreme-scale Analysis and Visualization (ISAV)
     year: 2017
     extra: Denver, CO
     url: https://cdux.cs.uoregon.edu/pubs/LiISAV.pdf
@@ -211,7 +211,7 @@ items  :
       - Mininni, P.
       - Clyne, J.
       - Childs, H.
-    journal: IEEE International Conference on Cluster Computing (CLUSTER)
+    conference: IEEE International Conference on Cluster Computing (CLUSTER)
     year: 2017
     extra: Honolulu, HI
     url: https://cdux.cs.uoregon.edu/pubs/LiCluster.pdf
@@ -224,7 +224,7 @@ items  :
       - Hammerling, D.
       - Li, S.
       - Clyne, J.
-    journal: The 1st International Workshop on Data Reduction for Big Scientific Data (DRBSD-1)
+    conference: The 1st International Workshop on Data Reduction for Big Scientific Data (DRBSD-1)
     year: 2017
     extra: Frankfurt, Germany
     url: https://cdux.cs.uoregon.edu/pubs/LiDRBSD.pdf
@@ -238,7 +238,7 @@ items  :
       - Sewell, C.
       - Clyne, J.
       - Childs, H.
-    journal: Eurographics Symposium on Parallel Graphics and Visualization (EGPGV)
+    conference: Eurographics Symposium on Parallel Graphics and Visualization (EGPGV)
     year: 2017
     extra: Barcelona, Spain
     url: https://cdux.cs.uoregon.edu/pubs/LiEGPGV.pdf
@@ -251,7 +251,7 @@ items  :
       - Potter, K.
       - Clyne, J.
       - Childs, H.
-    journal: IEEE Symposium on Large Data Visualization and Analysis (LDAV)
+    conference: IEEE Symposium on Large Data Visualization and Analysis (LDAV)
     year: 2015
     extra: Chicago, IL
     url: https://cdux.cs.uoregon.edu/pubs/LiLDAV.pdf

--- a/data/presentations.yml
+++ b/data/presentations.yml
@@ -1,0 +1,241 @@
+enable : true
+title  : PRESENTATIONS
+image  : images/banners/aurora.jpg
+items  :
+
+
+  - title: Project Pythia - A Pangeo Community Tool for Open-Source Education
+    authors:
+      - Kent, J.
+    journal: AGU 2022
+    year: 2022
+    extra: Chicago, IL
+    url: https://docs.google.com/presentation/d/19oWV7LULijtIYObrNW3ccoRLNFV9lYA0APuPlXAx_z8/edit?usp=sharing
+
+  - title: Beyond Visuals - Examining the Experiences of Geoscience Professionals With Vision Disabilities in Accessing Data Visualizations
+    authors:
+      - Cherukuru, N.
+      - Rehme, M.
+      - Bailey, D.
+      - Fourment, T.
+      - Hathaway, B.
+      - Holland, M.
+    journal: IEEE Vis 2022
+    year: 2022
+    url:
+
+  - title: Pivoting to Python - Lessons Learned in Recreating the NCAR Command Language in Python
+    authors:
+      - Sizemore, M.
+      - Eroglu, O.
+      - Zacharias, A.
+      - Kootz, A.
+    journal: AMS Annual Meeting 2022
+    year: 2022
+    url: https://ams.confex.com/ams/102ANNUAL/meetingapp.cgi/Paper/392637
+
+  - title: NCAR's GeoCAT Announcement of Computational Tools
+    authors:
+      - Craker, H.
+      - Kootz, A.
+      - Zacharias, A.
+      - Sizemore, M.
+      - Eroglu, O.
+    journal: AMS Annual Meeting 2022
+    year: 2022
+    url: https://ams.confex.com/ams/102ANNUAL/meetingapp.cgi/Paper/395377
+
+  - title: Project Raijin - Community Geoscience Analysis Tools for Unstructured Grids
+    authors:
+      - Clyne, J.
+      - Eroglu, O.
+      - Medeiros, B.
+      - Zarzycki, C. M.
+    journal: AGU Fall Meeting 2021
+    year: 2021
+    url: https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/901711
+
+  - title: Pangeo and Project Pythia - Helping Geoscientists Navigate the Scientific Python Ecosystem (Invited)
+    authors:
+      - Paul, K.
+      - Banihirwe, A.
+      - Camron, D.
+      - Clyne, J.
+      - Eroglu, O.
+      - Grover, M.
+      - Kent, J.
+      - May, R.
+      - Rose, B. E. J.
+      - Tyle, K.
+    journal: AGU Fall Meeting 2021
+    year: 2021
+    url: https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/831257
+
+  - title: Expanding and Strengthening the Transition from NCL to Python Visualizations
+    authors:
+      - Lincoln, E.
+      - Li, J.
+      - Zacharias, A.
+      - Sizemore, M.
+      - Eroglu, O.
+      - Kent, J.
+    journal: AGU Fall Meeting 2021
+    year: 2021
+    url: https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/973469
+
+  - title: Geoscience Community Analysis Toolkit (GeoCAT)
+    authors:
+      - Eroglu, O.
+      - Clyne, J.
+      - Kootz, A.
+      - Sizemore, M.
+      - Zacharias, A.
+    journal: AMS Annual Meeting 2021
+    year: 2021
+    url: https://ams.confex.com/ams/101ANNUAL/meetingapp.cgi/Paper/379186
+
+  - title: Rebuilding the NCL Visualization Gallery in Python
+    authors:
+      - Craker, H. R.
+      - Fiorino, C. A.
+      - Sizemore, M. V.
+    journal: AMS Annual Meeting 2021
+    year: 2021
+    url: https://ams.confex.com/ams/101ANNUAL/meetingapp.cgi/Paper/378236
+
+  - title: GeoCAT - The NCL Pivot to Python
+    authors:
+      - Clyne, J.
+    journal: AMS Annual Meeting 2020
+    year: 2020
+    url: https://ams.confex.com/ams/2020Annual/meetingapp.cgi/Paper/365970
+
+  - title: Earth Science Data Visualization Through Augmented Coloring Books
+    authors:
+      - Cherukuru, N.
+      - Scheitlin, T.
+      - Rehme, M.
+    journal: AMS Annual Meeting 2018
+    year: 2018
+    url:
+
+  - title: Using Neural Networks for Two Dimensional Scientific Data Compression
+    authors:
+      - Hayne, L.
+      - Clyne, J.
+      - Li, S.
+    journal: The Second International Workshop on Big Data Reduction (IWBDR)
+    year: 2021
+    url: ../pdfs/IWBDR_sub.pdf
+
+  - title: HashFight, A Platform-portable Hash Table for Multi-core and Many-core Architectures
+    authors:
+      - Lessley, B.
+      - Li, S.
+      - Childs, H.
+    journal: IS&T Conference on Visualization and Data Analysis (VDA)
+    year: 2020
+    extra: Burlingame, CA
+    url: https://doi.org/10.2352/ISSN.2470-1173.2020.1.VDA-376
+
+  - title: Dynamic I/O Budget Reallocation For In Situ Wavelet Compression
+    authors:
+      - Marsaglia, N.
+      - Li, S.
+      - Larsen, M.
+      - Childs, H.
+    journal: Eurographics Symposium on Parallel Graphics and Visualization (EGPGV)
+    year: 2019
+    extra: Porto, Portugal
+    url: https://cdux.cs.uoregon.edu/pubs/MarsagliaEGPGV.pdf
+
+  - title: Error-Controlled Lossy Compression Optimized for High Compression Ratios of Scientific Datasets
+    authors:
+      - Liang, X.
+      - Di, S.
+      - Tao, D.
+      - Li, S.
+      - Li, S.
+      - Guo, H.
+      - Chen, Z.
+      - Cappello, F.
+    journal: IEEE International Conference on Big Data
+    year: 2018
+    extra: Seattle, WA
+    url: https://ieeexplore.ieee.org/document/8622520
+
+  - title: Enabling Explorative Visualization With Full Temporal Resolution Via In Situ Calculation Of Temporal Intervals
+    authors:
+      - Marsaglia, N.
+      - Li, S.
+      - Childs, H.
+    journal: ISC Workshop On In Situ Visualization, Introduction & Applications (WOIV)
+    year: 2018
+    extra: Frankfurt, Germany
+    url: https://cdux.cs.uoregon.edu/pubs/MarsagliaWOIV.pdf
+
+
+  - title: Performance Impacts of In Situ Wavelet Compression on Scientific Simulations
+    authors:
+      - Li, S.
+      - Larsen, M.
+      - Clyne, J.
+      - Childs, H.
+    journal: In Situ Infrastructures for Enabling Extreme-scale Analysis and Visualization (ISAV)
+    year: 2017
+    extra: Denver, CO
+    url: https://cdux.cs.uoregon.edu/pubs/LiISAV.pdf
+
+
+  - title: Spatiotemporal Wavelet Compression for Visualization of Scientific Simulation Data
+    authors:
+      - Li, S.
+      - Sane, S.
+      - Orf, L.
+      - Mininni, P.
+      - Clyne, J.
+      - Childs, H.
+    journal: IEEE International Conference on Cluster Computing (CLUSTER)
+    year: 2017
+    extra: Honolulu, HI
+    url: https://cdux.cs.uoregon.edu/pubs/LiCluster.pdf
+
+
+  - title: Toward a Multi-method Approach, Lossy Data Compression for Climate Simulation Data
+    authors:
+      - Baker, A.
+      - Xu, H.
+      - Hammerling, D.
+      - Li, S.
+      - Clyne, J.
+    journal: The 1st International Workshop on Data Reduction for Big Scientific Data (DRBSD-1)
+    year: 2017
+    extra: Frankfurt, Germany
+    url: https://cdux.cs.uoregon.edu/pubs/LiDRBSD.pdf
+
+
+  - title: Achieving Portable Performance For Wavelet Compression Using Data Parallel Primitives
+    authors:
+      - Li, S.
+      - Marsaglia, N.
+      - Chen, V.
+      - Sewell, C.
+      - Clyne, J.
+      - Childs, H.
+    journal: Eurographics Symposium on Parallel Graphics and Visualization (EGPGV)
+    year: 2017
+    extra: Barcelona, Spain
+    url: https://cdux.cs.uoregon.edu/pubs/LiEGPGV.pdf
+
+
+  - title: Evaluating the Efficacy of Wavelet Configurations on Turbulent-Flow Data.
+    authors:
+      - Li, S.
+      - Gruchalla, K.
+      - Potter, K.
+      - Clyne, J.
+      - Childs, H.
+    journal: IEEE Symposium on Large Data Visualization and Analysis (LDAV)
+    year: 2015
+    extra: Chicago, IL
+    url: https://cdux.cs.uoregon.edu/pubs/LiLDAV.pdf

--- a/data/presentations.yml
+++ b/data/presentations.yml
@@ -53,6 +53,14 @@ items  :
     year: 2022
     url: https://ams.confex.com/ams/102ANNUAL/meetingapp.cgi/Paper/395377
 
+  - title: NCAR Earth System Data Science Initiative (ESDS) Educational Efforts
+    authors:
+      - Kent, J.
+    journal: AGU 2021
+    year: 2021
+    extra: New Orleans, LA
+    url: https://drive.google.com/file/d/1pidWOdzD9S95M-e1OvC04pY_tD5hURea/view?usp=share_link
+    
   - title: Project Raijin - Community Geoscience Analysis Tools for Unstructured Grids
     authors:
       - Clyne, J.

--- a/data/publications.yml
+++ b/data/publications.yml
@@ -1,8 +1,8 @@
 enable : true
-title  : PUBLICATIONS & PRESENTATIONS
+title  : PUBLICATIONS
 image  : images/banners/aurora.jpg
 items  :
-           
+
   - title: The Geoscience Community Analysis Toolkit - An Open Development, Community Driven
            Toolkit in the Scientific Python Ecosystem
     authors:
@@ -29,53 +29,6 @@ items  :
     year: 2022
     url:
 
-  - title: Pivoting to Python - Lessons Learned in Recreating the NCAR Command Language in Python
-    authors:
-      - Sizemore, M.
-      - Eroglu, O.
-      - Zacharias, A.
-      - Kootz, A.
-    journal: AMS Annual Meeting 2022
-    year: 2022
-    url: https://ams.confex.com/ams/102ANNUAL/meetingapp.cgi/Paper/392637
-
-  - title: NCAR's GeoCAT Announcement of Computational Tools
-    authors:
-      - Craker, H.
-      - Kootz, A.
-      - Zacharias, A.
-      - Sizemore, M.
-      - Eroglu, O.
-    journal: AMS Annual Meeting 2022
-    year: 2022
-    url: https://ams.confex.com/ams/102ANNUAL/meetingapp.cgi/Paper/395377
-
-  - title: Project Raijin - Community Geoscience Analysis Tools for Unstructured Grids
-    authors:
-      - Clyne, J.
-      - Eroglu, O.
-      - Medeiros, B.
-      - Zarzycki, C. M.
-    journal: AGU Fall Meeting 2021
-    year: 2021
-    url: https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/901711
-
-  - title: Pangeo and Project Pythia - Helping Geoscientists Navigate the Scientific Python Ecosystem (Invited)
-    authors:
-      - Paul, K.
-      - Banihirwe, A.
-      - Camron, D.
-      - Clyne, J.
-      - Eroglu, O.
-      - Grover, M.
-      - Kent, J.
-      - May, R.
-      - Rose, B. E. J.
-      - Tyle, K.
-    journal: AGU Fall Meeting 2021
-    year: 2021
-    url: https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/831257
-
   - title: Optimization of DNS code and visualization of entrainment and mixing phenomena at cloud edges
     authors:
       - Bipin, K.
@@ -97,42 +50,9 @@ items  :
       - Lauer, AJ.
       - Scheitlin, T.
       - Bhagchandani, B.
-
     journal: Museums and Web
     year: 2021
     url: https://mw21.museweb.net/paper/using-augmented-reality-ar-to-create-immersive-and-accessible-museums-for-people-with-vision-impairments/index.html
-
-  - title: Expanding and Strengthening the Transition from NCL to Python Visualizations
-    authors:
-      - Lincoln, E.
-      - Li, J.
-      - Zacharias, A.
-      - Sizemore, M.
-      - Eroglu, O.
-      - Kent, J.
-    journal: AGU Fall Meeting 2021
-    year: 2021
-    url: https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/973469
-
-  - title: Geoscience Community Analysis Toolkit (GeoCAT)
-    authors:
-      - Eroglu, O.
-      - Clyne, J.
-      - Kootz, A.
-      - Sizemore, M.
-      - Zacharias, A.
-    journal: AMS Annual Meeting 2021
-    year: 2021
-    url: https://ams.confex.com/ams/101ANNUAL/meetingapp.cgi/Paper/379186
-
-  - title: Rebuilding the NCL Visualization Gallery in Python
-    authors:
-      - Craker, H. R.
-      - Fiorino, C. A.
-      - Sizemore, M. V.
-    journal: AMS Annual Meeting 2021
-    year: 2021
-    url: https://ams.confex.com/ams/101ANNUAL/meetingapp.cgi/Paper/378236
 
   - title: Visual Comparator - An Interactive Tool for Dynamic Spatiotemporal Comparative Visualizations
     authors:
@@ -142,13 +62,6 @@ items  :
     year: 2020
     extra: E1861–E1869
     url: https://journals.ametsoc.org/view/journals/bams/101/10/bamsD190266.xml
-
-  - title: GeoCAT - The NCL Pivot to Python
-    authors:
-      - Clyne, J.
-    journal: AMS Annual Meeting 2020
-    year: 2020
-    url: https://ams.confex.com/ams/2020Annual/meetingapp.cgi/Paper/365970
 
   - title: Vapor, A visualization package tailored to analyze simulation data in earth system science
     authors:
@@ -160,15 +73,6 @@ items  :
     year: 2019
     extra: "10(9), 488"
     url: https://www.mdpi.com/2073-4433/10/9/488
-
-  - title: Earth Science Data Visualization Through Augmented Coloring Books
-    authors:
-      - Cherukuru, N.
-      - Scheitlin, T.
-      - Rehme, M.
-    journal: AMS Annual Meeting 2018
-    year: 2018
-    url:
 
   - title: Data Reduction Techniques for Simulation, Visualization, and Data Analysis
     authors:
@@ -192,124 +96,3 @@ items  :
     year: 2022
     extra: pp. 37--59
     url: https://link.springer.com/chapter/10.1007/978-3-030-81627-8_3
-
-  - title: Using Neural Networks for Two Dimensional Scientific Data Compression
-    authors:
-      - Hayne, L.
-      - Clyne, J.
-      - Li, S.
-    journal: The Second International Workshop on Big Data Reduction (IWBDR)
-    year: 2021
-    url: ../pdfs/IWBDR_sub.pdf
-
-  - title: HashFight, A Platform-portable Hash Table for Multi-core and Many-core Architectures
-    authors:
-      - Lessley, B.
-      - Li, S.
-      - Childs, H.
-    journal: IS&T Conference on Visualization and Data Analysis (VDA)
-    year: 2020
-    extra: Burlingame, CA
-    url: https://doi.org/10.2352/ISSN.2470-1173.2020.1.VDA-376
-
-  - title: Dynamic I/O Budget Reallocation For In Situ Wavelet Compression
-    authors:
-      - Marsaglia, N.
-      - Li, S.
-      - Larsen, M.
-      - Childs, H.
-    journal: Eurographics Symposium on Parallel Graphics and Visualization (EGPGV)
-    year: 2019
-    extra: Porto, Portugal
-    url: https://cdux.cs.uoregon.edu/pubs/MarsagliaEGPGV.pdf
-
-  - title: Error-Controlled Lossy Compression Optimized for High Compression Ratios of Scientific Datasets
-    authors:
-      - Liang, X.
-      - Di, S.
-      - Tao, D.
-      - Li, S.
-      - Li, S.
-      - Guo, H.
-      - Chen, Z.
-      - Cappello, F.
-    journal: IEEE International Conference on Big Data
-    year: 2018
-    extra: Seattle, WA
-    url: https://ieeexplore.ieee.org/document/8622520
-
-  - title: Enabling Explorative Visualization With Full Temporal Resolution Via In Situ Calculation Of Temporal Intervals
-    authors:
-      - Marsaglia, N.
-      - Li, S.
-      - Childs, H.
-    journal: ISC Workshop On In Situ Visualization, Introduction & Applications (WOIV)
-    year: 2018
-    extra: Frankfurt, Germany
-    url: https://cdux.cs.uoregon.edu/pubs/MarsagliaWOIV.pdf
-
-
-  - title: Performance Impacts of In Situ Wavelet Compression on Scientific Simulations
-    authors:
-      - Li, S.
-      - Larsen, M.
-      - Clyne, J.
-      - Childs, H.
-    journal: In Situ Infrastructures for Enabling Extreme-scale Analysis and Visualization (ISAV)
-    year: 2017
-    extra: Denver, CO
-    url: https://cdux.cs.uoregon.edu/pubs/LiISAV.pdf
-
-
-  - title: Spatiotemporal Wavelet Compression for Visualization of Scientific Simulation Data
-    authors:
-      - Li, S.
-      - Sane, S.
-      - Orf, L.
-      - Mininni, P.
-      - Clyne, J.
-      - Childs, H.
-    journal: IEEE International Conference on Cluster Computing (CLUSTER)
-    year: 2017
-    extra: Honolulu, HI
-    url: https://cdux.cs.uoregon.edu/pubs/LiCluster.pdf
-
-
-  - title: Toward a Multi-method Approach, Lossy Data Compression for Climate Simulation Data
-    authors:
-      - Baker, A.
-      - Xu, H.
-      - Hammerling, D.
-      - Li, S.
-      - Clyne, J.
-    journal: The 1st International Workshop on Data Reduction for Big Scientific Data (DRBSD-1)
-    year: 2017
-    extra: Frankfurt, Germany
-    url: https://cdux.cs.uoregon.edu/pubs/LiDRBSD.pdf
-
-
-  - title: Achieving Portable Performance For Wavelet Compression Using Data Parallel Primitives
-    authors:
-      - Li, S.
-      - Marsaglia, N.
-      - Chen, V.
-      - Sewell, C.
-      - Clyne, J.
-      - Childs, H.
-    journal: Eurographics Symposium on Parallel Graphics and Visualization (EGPGV)
-    year: 2017
-    extra: Barcelona, Spain
-    url: https://cdux.cs.uoregon.edu/pubs/LiEGPGV.pdf
-
-
-  - title: Evaluating the Efficacy of Wavelet Configurations on Turbulent-Flow Data.
-    authors:
-      - Li, S.
-      - Gruchalla, K.
-      - Potter, K.
-      - Clyne, J.
-      - Childs, H.
-    journal: IEEE Symposium on Large Data Visualization and Analysis (LDAV)
-    year: 2015
-    extra: Chicago, IL
-    url: https://cdux.cs.uoregon.edu/pubs/LiLDAV.pdf

--- a/themes/ncar/assets/scss/components/_presentations.scss
+++ b/themes/ncar/assets/scss/components/_presentations.scss
@@ -1,0 +1,112 @@
+.site-presentations{
+  &-header{
+    padding-top: 180px;
+    background-color: $gray;
+    background-size: cover;
+    @include mobile{
+      padding-top: 100px;
+      text-align: center;
+    }
+    h1{
+      color: $white;
+      letter-spacing: 2px;
+      font-weight: 800;
+      font-size: 36px;
+      line-height: 60px;
+      padding-bottom: 0px;
+      text-transform: uppercase;
+      margin-bottom: 50px;
+    }
+    h6{
+     color: $primary-color;
+     font-size: 20px;
+    }
+  }
+  &-section{
+    padding-top: 0px;
+    padding-bottom: 80px;
+    background-color: $gray;
+    @include mobile{
+      padding-top: 0px;
+      text-align: center;
+    }
+  }
+  &-content{
+    background: $gray;
+    width: 100%;
+    padding: 50px 20px;
+
+    span{
+      color: $secondary-color;
+      font-weight: 600;
+    }
+  }
+  &-items{
+    li {
+      margin-bottom: 10px;
+    }
+  }
+  &-wrapper{
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  &-git{
+    background: $primary-color;
+    border-radius: 25px;
+    width: 40%;
+    padding: 25px 10px;
+    @include desktop{
+      width: 100%;
+      margin-bottom: 20px;
+    }
+    h1{
+      color: $white;
+      font-weight: 400;
+      font-size: 35px;
+      line-height: 60px;
+      letter-spacing: 1px;
+      text-transform: none;
+    }
+    a{
+      color: $white;
+      transition: all 0.3s $site-ease;
+      display: block;
+    }
+  }
+  &-docs{
+    @extend .site-software-git;
+    background: $secondary-color;
+    h1{
+    font-size: 24px;
+    }
+  }
+  &-spacer{
+    width:80px;
+  }
+  &-buttons{
+    margin: 0;
+    padding: 0;
+    li{
+      display: inline-block;
+      @include mobile{
+        display: block;
+      }
+      &:not(:last-child){
+        margin-right: 30px;
+        @include mobile{
+          margin-right: 0;
+          margin-bottom: 20px;
+        }
+      }
+      .btn{
+        font-weight: 600;
+        @include mobile{
+          width: 90%;
+          margin: 0 auto;
+          display: block;
+        }
+      }
+    }
+  }
+}

--- a/themes/ncar/assets/scss/style.scss
+++ b/themes/ncar/assets/scss/style.scss
@@ -20,6 +20,8 @@
 
 @import "components/publications";
 
+@import "components/presentations";
+
 @import "components/siparcs";
 
 @import "components/packages";

--- a/themes/ncar/layouts/presentations/list.html
+++ b/themes/ncar/layouts/presentations/list.html
@@ -1,0 +1,43 @@
+{{ define "main" }}
+{{ with .Site.Data.presentations }}
+{{ if .enable }}
+<section class="site-presentations-header" style="background-image: url({{ .image | absURL }});">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 text-center">
+        <h1>
+          {{ .title }}
+        </h1>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="site-presentations-content">
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+        <div class="site-presentations-items">
+          {{ $year := "" }}
+          {{ range $item := sort .items "year" "desc" }}
+          {{   $is_new_year := ne $year $item.year }}
+          {{   if $is_new_year }}
+          {{     if ne $year "" }}
+          </ul>
+          {{     end }}
+          {{     $year = $item.year }}
+          <span>{{ $year }}</span>
+          <ul>
+          {{   end }}
+            {{ if .url }}<a href="{{ .url }}">{{ end }}
+            <li>{{ delimit .authors ", " }} "<em>{{ .title |  }}</em>" <b>{{ .journal }}</b>, ({{ .year }}){{ if .extra }}, {{ .extra }}{{ else }}{{ end }}.</li>
+            {{ if .url }}</a>{{ end }}
+          {{ end }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
This PR does the infrastructure work for a separate presentations page.

Work to be done:
- replace presentation URLs with links to slide or poster pdfs (in VAST google drive or on GitHub?)