### PR TITLE
fix syntax error in update metrics action

### DIFF
--- a/.github/workflows/update-metrics.yaml
+++ b/.github/workflows/update-metrics.yaml
@@ -31,7 +31,7 @@ jobs:
 
         metrics_file = 'data/metrics.yml'
         publications_file = 'data/publications.yml'
-        presentations file = 'data/presentations.yml'
+        presentations_file = 'data/presentations.yml'
         packages_file = 'data/packages.yml'
         siparcs_file = 'data/siparcs.yml'
           


### PR DESCRIPTION
I think I tracked down the error in https://github.com/NCAR/vast/actions/runs/3961367193

I had a space instead of an underscore in a variable. oops!