### PR TITLE
Update current and past interns on the "About" page

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -27,6 +27,11 @@ members  :
     ncaruname   : katelynw
     githubuname : kafitzgerald
 
+  - name        : IAN FRANDA
+    designation : SIParCS Intern
+    ncaruname   : ifranda
+    githubuname : ifranda
+
   - name        : STANISLAW 'Stas' JAROSZYNSKI
     designation : Software Engineer
     ncaruname   : stasj

--- a/data/team_alumni.yml
+++ b/data/team_alumni.yml
@@ -8,12 +8,12 @@ members  :
     githubuname : hCraker
 
   - name        : ALINA GUHA
-    designation : SIParCS Intern
+    designation : SIParCS Intern 2022
     ncaruname   : 
-    githubuname : 
+    githubuname : alinejg
 
   - name        : HANIYE KASHGARANI
-    designation : SIParCS Intern
+    designation : SIParCS Intern 2022
     ncaruname   : 
     githubuname : haniyeka
 
@@ -23,17 +23,17 @@ members  :
     githubuname : pilotchute
 
   - name        : JIAQI LI
-    designation : SIParCS Intern
+    designation : SIParCS Intern 2021
     ncaruname   : 
     githubuname : Jiaqi-beep
 
   - name        : ERIN LINCOLN
-    designation : SIParCS Intern
+    designation : SIParCS Intern 2021
     ncaruname   : 
     githubuname : erinlincoln
 
   - name        : DAPHNE QUINT
-    designation : SIParCS Intern
+    designation : SIParCS Intern 2022
     ncaruname   : 
     githubuname : doqhne
 
@@ -43,12 +43,12 @@ members  :
     githubuname : marodrig
 
   - name        : SHIQI SHENG
-    designation : SIParCS Intern
+    designation : SIParCS Intern 2020
     ncaruname   : 
     githubuname : shiqisheng2036
 
   - name        : AASHIQ SHEIKH
-    designation : SIParCS Intern
+    designation : SIParCS Intern 2019
     ncaruname   : 
     githubuname : aashiqsworld
 

--- a/data/team_alumni.yml
+++ b/data/team_alumni.yml
@@ -12,6 +12,11 @@ members  :
     ncaruname   : 
     githubuname : 
 
+  - name        : HANIYE KASHGARANI
+    designation : SIParCS Intern
+    ncaruname   : 
+    githubuname : haniyeka
+
   - name        : ALEA KOOTZ
     designation : Software Engineer
     ncaruname   : 

--- a/data/team_alumni.yml
+++ b/data/team_alumni.yml
@@ -7,10 +7,30 @@ members  :
     ncaruname   : 
     githubuname : hCraker
 
+  - name        : ALINA GUHA
+    designation : SIParCS Intern
+    ncaruname   : 
+    githubuname : 
+
   - name        : ALEA KOOTZ
     designation : Software Engineer
     ncaruname   : 
     githubuname : pilotchute
+
+  - name        : JIAQI LI
+    designation : SIParCS Intern
+    ncaruname   : 
+    githubuname : Jiaqi-beep
+
+  - name        : ERIN LINCOLN
+    designation : SIParCS Intern
+    ncaruname   : 
+    githubuname : erinlincoln
+
+  - name        : DAPHNE QUINT
+    designation : SIParCS Intern
+    ncaruname   : 
+    githubuname : doqhne
 
   - name        : MARIO RODRIGUEZ
     designation : Software Engineer
@@ -18,18 +38,18 @@ members  :
     githubuname : marodrig
 
   - name        : SHIQI SHENG
-    designation : SIPARCS Intern
+    designation : SIParCS Intern
     ncaruname   : 
     githubuname : shiqisheng2036
 
   - name        : AASHIQ SHEIKH
-    designation : SIPARCS Intern
+    designation : SIParCS Intern
     ncaruname   : 
     githubuname : aashiqsworld
 
   - name        : COLLIN SINCLAIR
     designation : Scientific Data Visualization Designer
-    ncaruname   : csinclair
+    ncaruname   : 
     githubuname : collinsinclair
 
   - name        : MICHAELA SIZEMORE


### PR DESCRIPTION
Updated the About page to include some current and past SIParCS interns.

Also:
* changed SIPARCS to SIParCS
* removed a no longer valid NCAR username from the alumni list

Closes #108.