### PR TITLE
Remove interns from team_alumni.yml

### DIFF
--- a/data/team_alumni.yml
+++ b/data/team_alumni.yml
@@ -17,19 +17,9 @@ members  :
     ncaruname   : 
     githubuname : marodrig
 
-  - name        : SHIQI SHENG
-    designation : SIPARCS Intern
-    ncaruname   : 
-    githubuname : shiqisheng2036
-
-  - name        : AASHIQ SHEIKH
-    designation : SIPARCS Intern
-    ncaruname   : 
-    githubuname : aashiqsworld
-
   - name        : COLLIN SINCLAIR
     designation : Scientific Data Visualization Designer
-    ncaruname   : csinclair
+    ncaruname   : 
     githubuname : collinsinclair
 
   - name        : MICHAELA SIZEMORE


### PR DESCRIPTION
Remove partial list of prior interns from team_alumni.yml keeping all intern info on the internships page.

Closes #108 