### PR TITLE
consistent VAST name meaning

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Visualization and Analysis Software Team, NCAR
+Copyright (c) 2022 Visualization & Analysis Systems Technologies, NCAR
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 baseURL       : https://vast.ucar.edu/
 languageCode  : en-us
-title         : "VAST | Visualization and Analysis Software and Technology"
+title         : "VAST | Visualization & Analysis Systems Technologies"
 theme         : ncar
 enableGitInfo : true
 summarylength : 25
@@ -46,7 +46,7 @@ menu:
 params:
   name: VAST
   dateFormat: "26 FEB 1994"
-  description: "VAST is the Visualization and Analysis Software and Technology section at the National Center for Atmospheric Research (NCAR)."
+  description: "VAST is the Visualization & Analysis Systems Technologies section at the National Center for Atmospheric Research (NCAR)."
   author: "VAST"
   email: "vast@ucar.edu"
 

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,10 +1,10 @@
 ---
-title: "VISUALIZATION AND ANALYSIS SOFTWARE AND TECHNOLOGY"
+title: "VISUALIZATION AND ANALYSIS SYSTEMS TECHNOLOGIES"
 date: 2022-04-27T00:00:00-06:00
 image: images/banners/limb.jpg
 ---
 
-NCAR’s Visualization and Analysis Software and Technology (VAST) section helps scientists, students, policy makers, and the public better understand enormous volumes of geoscientific data. Numerical simulations of complex natural phenomena, running on some of the world’s most powerful supercomputers, and a wide range of earth observing instruments all produce tremendous amounts of numerical data about the natural world. Helping explore, explain, understand, and gain insight into these complex troves of data is the mission of VAST.
+NCAR’s Visualization & Analysis Systems Technologies (VAST) section helps scientists, students, policy makers, and the public better understand enormous volumes of geoscientific data. Numerical simulations of complex natural phenomena, running on some of the world’s most powerful supercomputers, and a wide range of earth observing instruments all produce tremendous amounts of numerical data about the natural world. Helping explore, explain, understand, and gain insight into these complex troves of data is the mission of VAST.
 
 ---
 


### PR DESCRIPTION
VAST name was inconsistent across site. @erogluorhan confirmed with @clyne that it should be "Visualization & Analysis Systems Technologies" everywhere. This PR fixes this.